### PR TITLE
hotfix: name of the  field state is chaged

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "netstat2"
 version = "0.9.1"
 authors = ["Ohad Ravid <ohad.rv@gmail.com>", "ivxvm <ivxvm@protonmail.com>"]
+rust-version = "1.70.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/integrations/linux/netlink_iterator.rs
+++ b/src/integrations/linux/netlink_iterator.rs
@@ -190,7 +190,7 @@ unsafe fn parse_tcp_state(diag_msg: &inet_diag_msg, rtalen: usize) -> TcpState {
     while RTA_OK!(attr, len) {
         if (&*attr).rta_type == INET_DIAG_INFO as u16 {
             let tcpi = &*(RTA_DATA!(attr) as *const tcp_info);
-            return TcpState::from(tcpi.state);
+            return TcpState::from(tcpi.tcpi_state);
         }
         attr = RTA_NEXT!(attr, len);
     }


### PR DESCRIPTION
Also add `rust-version = "1.70.0"` to the crate. 